### PR TITLE
Remove dependency on remove-markdown module

### DIFF
--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -21,7 +21,6 @@ import {
   NrqlQuery
 } from 'nr1';
 
-const removeMd = require('remove-markdown');
 const ReactMarkdown = require('react-markdown');
 const JSONPretty = require('react-json-pretty');
 
@@ -95,15 +94,8 @@ export default class SampleQuery extends React.Component {
 
   render() {
     const { nrql, span, markdown } = this.props;
-    let nrqlPlain = removeMd(
-      nrql
-        .replace(/\\\*/g, ' \\* ')
-        .replace(/\\_/g, ' \\_ ')
-        .replace(/\\\[/g, ' \\[ ')
-    ); // deal with weird asterix encoding issue
-    nrqlPlain = nrqlPlain.replace(/\s\\\*\s/g, '*');
-    nrqlPlain = nrqlPlain.replace(/\s\\_\s/g, '_');
-    nrqlPlain = nrqlPlain.replace(/\s\\\[\s/g, '[');
+    let nrqlPlain=nrql.replace(/\*\*/g,'').replace(/\\\*/g,'*').replace(/\\\_/g,'_').replace(/\\\[/g, '[')
+    
     if (markdown === 'no') {
       nrqlPlain = nrql;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2230,11 +2230,6 @@
                 "xtend": "^4.0.1"
             }
         },
-        "remove-markdown": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
-            "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
-        },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
     "dependencies": {
         "@kunukn/react-collapse": "^1.2.7",
         "copy-to-clipboard": "^3.3.1",
-        "react-json-pretty": "^2.2.0",
-        "react-markdown": "^4.3.1",
-        "remove-markdown": "^0.3.0",
         "prop-types": "^15.6.2",
         "react": "^16.6.3",
-        "react-dom": "^16.6.3"
+        "react-dom": "^16.6.3",
+        "react-json-pretty": "^2.2.0",
+        "react-markdown": "^4.3.1"
     },
     "browserslist": [
         "last 2 versions",


### PR DESCRIPTION
The remove-markdown module had security issues, turns out a few regex's does a similar job.