### PR TITLE
Fallback Queries For Learners in Accounts with No APM Transaction Data

### DIFF
--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -83,8 +83,8 @@ export default class SampleQuery extends React.Component {
     return (
       <LessonContextConsumer>
         {context => {
-          { context.hasNoAPM  ? (nrql = fallbacknrql) : null ; 
-            context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : null }
+          { context.hasNoAPM  ? (nrql = fallbacknrql) : -1 ; 
+            context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : -1 }
           return (
             <Grid className="sample-query">
               <GridItem columnSpan={numSpan} style={{ height: '100%' }}>

--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -83,8 +83,8 @@ export default class SampleQuery extends React.Component {
     return (
       <LessonContextConsumer>
         {context => {
-          { context.hasNoAPM  ? nrql = fallbacknrql : nrqlPlain=nrqlPlain  }
-          { context.hasNoAPM  ? nrqlPlain = fallbacknrql : nrqlPlain=nrqlPlain  }
+          { context.hasNoAPM  ? (nrql = fallbacknrql) : null ; 
+            context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : null }
           return (
             <Grid className="sample-query">
               <GridItem columnSpan={numSpan} style={{ height: '100%' }}>

--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -83,8 +83,8 @@ export default class SampleQuery extends React.Component {
     return (
       <LessonContextConsumer>
         {context => {
-          { context.hasNoAPM  ? (nrql = fallbacknrql) : -1 ; 
-            context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : -1 }
+          // eslint-disable-next-line no-use-before-define
+          { context.hasNoAPM  ? (nrql = fallbacknrql) : -1 ; context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : -1 }
           return (
             <Grid className="sample-query">
               <GridItem columnSpan={numSpan} style={{ height: '100%' }}>

--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -83,8 +83,7 @@ export default class SampleQuery extends React.Component {
     return (
       <LessonContextConsumer>
         {context => {
-          // eslint-disable-next-line no-lone-blocks prettier/prettier
-          { context.hasNoAPM  ? (nrql = fallbacknrql) : -1 ; context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : -1 }
+          { context.hasNoAPM  ? (nrql = fallbacknrql) : -1 ; context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : -1 } // eslint-disable-line no-lone-blocks, prettier/prettier, no-unused-expressions
           return (
             <Grid className="sample-query">
               <GridItem columnSpan={numSpan} style={{ height: '100%' }}>

--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -26,6 +26,7 @@ export default class SampleQuery extends React.Component {
   static propTypes = {
     chartType: PropTypes.string,
     nrql: PropTypes.string,
+    fallbacknrql: PropTypes.string,
     span: PropTypes.string,
     markdown: PropTypes.string
   };
@@ -64,7 +65,7 @@ export default class SampleQuery extends React.Component {
   }
 
   render() {
-    const { nrql, span, markdown } = this.props;
+    let { nrql, span, markdown, fallbacknrql } = this.props;
     let nrqlPlain = nrql
       .replace(/\*\*/g, '')
       .replace(/\\\*/g, '*')
@@ -82,6 +83,8 @@ export default class SampleQuery extends React.Component {
     return (
       <LessonContextConsumer>
         {context => {
+          { context.hasNoAPM  ? nrql = fallbacknrql : nrqlPlain=nrqlPlain  }
+          { context.hasNoAPM  ? nrqlPlain = fallbacknrql : nrqlPlain=nrqlPlain  }
           return (
             <Grid className="sample-query">
               <GridItem columnSpan={numSpan} style={{ height: '100%' }}>

--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -83,7 +83,7 @@ export default class SampleQuery extends React.Component {
     return (
       <LessonContextConsumer>
         {context => {
-          // eslint-disable-next-line no-use-before-define
+          // eslint-disable-next-line no-lone-blocks prettier/prettier
           { context.hasNoAPM  ? (nrql = fallbacknrql) : -1 ; context.hasNoAPM  ? (nrqlPlain = fallbacknrql) : -1 }
           return (
             <Grid className="sample-query">

--- a/nerdlets/nrql-tutorial-nerdlet/contexts/LessonContext.js
+++ b/nerdlets/nrql-tutorial-nerdlet/contexts/LessonContext.js
@@ -7,6 +7,7 @@ export class LessonContextProvider extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     accountId: PropTypes.number,
+    hasNoAPM: PropTypes.bool,
     chooseLesson: PropTypes.func
   };
 
@@ -15,6 +16,7 @@ export class LessonContextProvider extends React.Component {
       <LessonContext.Provider
         value={{
           accountId: this.props.accountId,
+          hasNoAPM: this.props.hasNoAPM,
           chooseLesson: this.props.chooseLesson
         }}
       >

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -59,7 +59,7 @@ export default class NrqlTutorialNerdlet extends React.Component {
 
     let intendedState = {};
     if (accounts.length > 0) {
-      const APMbool = accounts[0].reportingEventTypes === null ? 'true' : 'false';
+      const APMbool = accounts[0].reportingEventTypes === null ? 'true' : 'false'; // eslint-disable-line prettier/prettier
       intendedState = {
         selectedAccount: accounts[0].id,
         hasNoAPM: APMbool,

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -204,13 +204,13 @@ export default class NrqlTutorialNerdlet extends React.Component {
                     <GridItem columnSpan={1}>Use data from account:</GridItem>
                     <GridItem columnSpan={5}>
                       <Select
-                        onChange={(event, value) => {
+                        onChange={(key, value) => {
+                          // eslint-disable-next-line no-use-before-define
                           const found = accounts.find(
                             ({ key }) => key === value
                           );
-                          const hasAPMbool = found.props.children.includes(
-                            'no recent APM data'
-                          );
+                          // eslint-disable-next-line no-use-before-define
+                          const hasAPMbool = found.props.children.includes('no recent APM data');
                           this.setState({ selectedAccount: value,
                              hasNoAPM: hasAPMbool
                           });

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -207,11 +207,11 @@ export default class NrqlTutorialNerdlet extends React.Component {
                         onChange={(event, value) => {
                           const found = accounts.find(({ key }) => key === value );
                           const hasAPMbool = found.props.children.includes(
-                            'no recent APM data');
-                          this.setState(
-                            { selectedAccount: value, hasNoAPM: hasAPMbool }
+                            'no recent APM data'
                             );
-                        }}
+                          this.setState({ selectedAccount: value,
+                             hasNoAPM: hasAPMbool });
+                      }}
                         value={selectedAccount}
                       >
                         {accounts}

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -61,6 +61,7 @@ export default class NrqlTutorialNerdlet extends React.Component {
     if (accounts.length > 0) {
       intendedState = {
         selectedAccount: accounts[0].id,
+        hasNoAPM: accounts[0].reportingEventTypes === null ? true : false,
         accounts: accounts.map(account => {
           return (
             <SelectItem value={String(account.id)} key={account.id}>
@@ -164,6 +165,7 @@ export default class NrqlTutorialNerdlet extends React.Component {
       currentLesson,
       accounts,
       selectedAccount,
+      hasNoAPM,
       noAccounts,
       languages,
       selectedLanguage
@@ -201,7 +203,13 @@ export default class NrqlTutorialNerdlet extends React.Component {
                     <GridItem columnSpan={5}>
                       <Select
                         onChange={(event, value) => {
-                          this.setState({ selectedAccount: value });
+                          const found = accounts.find( ({ key }) => key === value );
+                          const hasAPMbool = found.props.children.includes("no recent APM data")
+                          this.setState({ selectedAccount: value, hasNoAPM: hasAPMbool }, 
+                            //() => console.log("State Being Set: " + this.state.hasNoAPM),
+                            );
+                          //console.log(found);
+                          //console.log("Has No APM VAR: " +hasAPMbool);
                         }}
                         value={selectedAccount}
                       >
@@ -251,6 +259,7 @@ export default class NrqlTutorialNerdlet extends React.Component {
                 <GridItem columnSpan={9}>
                   <LessonContextProvider
                     accountId={Number(selectedAccount)}
+                    hasNoAPM={this.state.hasNoAPM}
                     chooseLesson={(level, lesson) => {
                       this.chooseLesson(level, lesson);
                       this.topRef.current.scrollIntoView();

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -205,15 +205,14 @@ export default class NrqlTutorialNerdlet extends React.Component {
                     <GridItem columnSpan={5}>
                       <Select
                         onChange={(key, value) => {
-                          // eslint-disable-next-line no-use-before-define
+                          // eslint-disable-next-line
                           const found = accounts.find(
                             ({ key }) => key === value
                           );
-                          // eslint-disable-next-line no-use-before-define
+                          // eslint-disable-next-line
                           const hasAPMbool = found.props.children.includes('no recent APM data');
-                          this.setState({ selectedAccount: value,
-                             hasNoAPM: hasAPMbool
-                          });
+                          // eslint-disable-next-line
+                          this.setState({ selectedAccount: value, hasNoAPM: hasAPMbool });
                         }}
                         value={selectedAccount}
                       >

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -211,7 +211,7 @@ export default class NrqlTutorialNerdlet extends React.Component {
                             );
                           this.setState({ selectedAccount: value,
                              hasNoAPM: hasAPMbool });
-                      }}
+                        }}
                         value={selectedAccount}
                       >
                         {accounts}

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -205,9 +205,9 @@ export default class NrqlTutorialNerdlet extends React.Component {
                     <GridItem columnSpan={5}>
                       <Select
                         onChange={(key, value) => {
-                          const found = accounts.find(({ key }) => key === value); // eslint-disable-line
-                          const hasAPMbool = found.props.children.includes('no recent APM data'); // eslint-disable-line
-                          this.setState({ selectedAccount: value, hasNoAPM: hasAPMbool }); // eslint-disable-line
+                          const found = accounts.find(({ key }) => key === value); // eslint-disable-line prettier/prettier
+                          const hasAPMbool = found.props.children.includes('no recent APM data'); // eslint-disable-line prettier/prettier
+                          this.setState({ selectedAccount: value, hasNoAPM: hasAPMbool }); // eslint-disable-line prettier/prettier
                         }}
                         value={selectedAccount}
                       >

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -59,7 +59,7 @@ export default class NrqlTutorialNerdlet extends React.Component {
 
     let intendedState = {};
     if (accounts.length > 0) {
-      let APMbool = accounts[0].reportingEventTypes === null ? true : false;
+      const APMbool = accounts[0].reportingEventTypes === null ? 'true' : 'false';
       intendedState = {
         selectedAccount: accounts[0].id,
         hasNoAPM: APMbool,
@@ -205,12 +205,15 @@ export default class NrqlTutorialNerdlet extends React.Component {
                     <GridItem columnSpan={5}>
                       <Select
                         onChange={(event, value) => {
-                          const found = accounts.find(({ key }) => key === value );
+                          const found = accounts.find(
+                            ({ key }) => key === value
+                          );
                           const hasAPMbool = found.props.children.includes(
                             'no recent APM data'
-                            );
+                          );
                           this.setState({ selectedAccount: value,
-                             hasNoAPM: hasAPMbool });
+                             hasNoAPM: hasAPMbool
+                          });
                         }}
                         value={selectedAccount}
                       >

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -59,9 +59,10 @@ export default class NrqlTutorialNerdlet extends React.Component {
 
     let intendedState = {};
     if (accounts.length > 0) {
+      let APMbool = accounts[0].reportingEventTypes === null ? true : false;
       intendedState = {
         selectedAccount: accounts[0].id,
-        hasNoAPM: accounts[0].reportingEventTypes === null ? true : false,
+        hasNoAPM: APMbool,
         accounts: accounts.map(account => {
           return (
             <SelectItem value={String(account.id)} key={account.id}>
@@ -165,7 +166,6 @@ export default class NrqlTutorialNerdlet extends React.Component {
       currentLesson,
       accounts,
       selectedAccount,
-      hasNoAPM,
       noAccounts,
       languages,
       selectedLanguage
@@ -186,6 +186,8 @@ export default class NrqlTutorialNerdlet extends React.Component {
       </Button>
     ));
 
+    NextLessonBt.displayName = 'NextLessonBt';
+
     // hide button on last lesson ?
     const showNextButton = !(
       currentLevel + 1 === LEVELS.length &&
@@ -203,13 +205,12 @@ export default class NrqlTutorialNerdlet extends React.Component {
                     <GridItem columnSpan={5}>
                       <Select
                         onChange={(event, value) => {
-                          const found = accounts.find( ({ key }) => key === value );
-                          const hasAPMbool = found.props.children.includes("no recent APM data")
-                          this.setState({ selectedAccount: value, hasNoAPM: hasAPMbool }, 
-                            //() => console.log("State Being Set: " + this.state.hasNoAPM),
+                          const found = accounts.find(({ key }) => key === value );
+                          const hasAPMbool = found.props.children.includes(
+                            'no recent APM data');
+                          this.setState(
+                            { selectedAccount: value, hasNoAPM: hasAPMbool }
                             );
-                          //console.log(found);
-                          //console.log("Has No APM VAR: " +hasAPMbool);
                         }}
                         value={selectedAccount}
                       >

--- a/nerdlets/nrql-tutorial-nerdlet/index.js
+++ b/nerdlets/nrql-tutorial-nerdlet/index.js
@@ -205,14 +205,9 @@ export default class NrqlTutorialNerdlet extends React.Component {
                     <GridItem columnSpan={5}>
                       <Select
                         onChange={(key, value) => {
-                          // eslint-disable-next-line
-                          const found = accounts.find(
-                            ({ key }) => key === value
-                          );
-                          // eslint-disable-next-line
-                          const hasAPMbool = found.props.children.includes('no recent APM data');
-                          // eslint-disable-next-line
-                          this.setState({ selectedAccount: value, hasNoAPM: hasAPMbool });
+                          const found = accounts.find(({ key }) => key === value); // eslint-disable-line
+                          const hasAPMbool = found.props.children.includes('no recent APM data'); // eslint-disable-line
+                          this.setState({ selectedAccount: value, hasNoAPM: hasAPMbool }); // eslint-disable-line
                         }}
                         value={selectedAccount}
                       >

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
@@ -57,7 +57,7 @@ export default function AggregateQuery() {
           </Trans>
         </em>
       </p>
-      <SampleQuery 
+      <SampleQuery
         nrql="SELECT **max(duration)** FROM Transaction "
         fallbacknrql="SELECT max(duration) FROM Public_APICall"
         span="6"
@@ -71,7 +71,7 @@ export default function AggregateQuery() {
           out.
         </Trans>
       </p>
-      <SampleQuery 
+      <SampleQuery
         nrql="SELECT **min(duration)** FROM Transaction "
         fallbacknrql="SELECT min(duration) FROM Public_APICall"
         span="6"
@@ -105,8 +105,8 @@ export default function AggregateQuery() {
       </p>
       <SampleQuery
         nrql="SELECT **count(*)** FROM Transaction"
-        fallbacknrql="SELECT count(*) FROM Public_APICall" 
-        span="6" 
+        fallbacknrql="SELECT count(*) FROM Public_APICall"
+        span="6"
       />
       <h2>
         <Trans i18nKey="Contents.H1">Lesson Summary</Trans>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
@@ -24,6 +24,7 @@ export default function AggregateQuery() {
       </p>
       <SampleQuery
         nrql="SELECT **average(duration)** FROM Transaction "
+        fallbacknrql="SELECT average(duration) FROM Public_APICall"
         span="6"
       />
 
@@ -56,7 +57,7 @@ export default function AggregateQuery() {
           </Trans>
         </em>
       </p>
-      <SampleQuery nrql="SELECT **max(duration)** FROM Transaction " span="6" />
+      <SampleQuery nrql="SELECT **max(duration)** FROM Transaction " fallbacknrql="SELECT max(duration) FROM Public_APICall" span="6" />
 
       <p>
         <Trans i18nKey="Contents.P7">
@@ -66,7 +67,7 @@ export default function AggregateQuery() {
           out.
         </Trans>
       </p>
-      <SampleQuery nrql="SELECT **min(duration)** FROM Transaction " span="6" />
+      <SampleQuery nrql="SELECT **min(duration)** FROM Transaction " fallbacknrql="SELECT min(duration) FROM Public_APICall" span="6" />
 
       <p>
         <Trans i18nKey="Contents.P8">
@@ -82,6 +83,7 @@ export default function AggregateQuery() {
       </p>
       <SampleQuery
         nrql="SELECT **sum(databaseCallCount)** FROM Transaction "
+        fallbacknrql="SELECT sum(duration) FROM Public_APICall"
         span="6"
       />
 
@@ -93,7 +95,7 @@ export default function AggregateQuery() {
           APM:
         </Trans>
       </p>
-      <SampleQuery nrql="SELECT **count(*)** FROM Transaction " span="6" />
+      <SampleQuery nrql="SELECT **count(*)** FROM Transaction " fallbacknrql="SELECT count(*) FROM Public_APICall" span="6" />
 
       <h2>
         <Trans i18nKey="Contents.H1">Lesson Summary</Trans>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
@@ -58,9 +58,9 @@ export default function AggregateQuery() {
         </em>
       </p>
       <SampleQuery 
-        nrql="SELECT **max(duration)** FROM Transaction " 
-        fallbacknrql="SELECT max(duration) FROM Public_APICall" 
-        span="6" 
+        nrql="SELECT **max(duration)** FROM Transaction "
+        fallbacknrql="SELECT max(duration) FROM Public_APICall"
+        span="6"
       />
 
       <p>
@@ -72,9 +72,9 @@ export default function AggregateQuery() {
         </Trans>
       </p>
       <SampleQuery 
-        nrql="SELECT **min(duration)** FROM Transaction " 
-        fallbacknrql="SELECT min(duration) FROM Public_APICall" 
-        span="6" 
+        nrql="SELECT **min(duration)** FROM Transaction "
+        fallbacknrql="SELECT min(duration) FROM Public_APICall"
+        span="6"
       />
 
       <p>
@@ -103,8 +103,8 @@ export default function AggregateQuery() {
           APM:
         </Trans>
       </p>
-      <SampleQuery 
-        nrql="SELECT **count(*)** FROM Transaction " 
+      <SampleQuery
+        nrql="SELECT **count(*)** FROM Transaction"
         fallbacknrql="SELECT count(*) FROM Public_APICall" 
         span="6" 
       />

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/AggregateQuery.js
@@ -57,7 +57,11 @@ export default function AggregateQuery() {
           </Trans>
         </em>
       </p>
-      <SampleQuery nrql="SELECT **max(duration)** FROM Transaction " fallbacknrql="SELECT max(duration) FROM Public_APICall" span="6" />
+      <SampleQuery 
+        nrql="SELECT **max(duration)** FROM Transaction " 
+        fallbacknrql="SELECT max(duration) FROM Public_APICall" 
+        span="6" 
+      />
 
       <p>
         <Trans i18nKey="Contents.P7">
@@ -67,7 +71,11 @@ export default function AggregateQuery() {
           out.
         </Trans>
       </p>
-      <SampleQuery nrql="SELECT **min(duration)** FROM Transaction " fallbacknrql="SELECT min(duration) FROM Public_APICall" span="6" />
+      <SampleQuery 
+        nrql="SELECT **min(duration)** FROM Transaction " 
+        fallbacknrql="SELECT min(duration) FROM Public_APICall" 
+        span="6" 
+      />
 
       <p>
         <Trans i18nKey="Contents.P8">
@@ -95,8 +103,11 @@ export default function AggregateQuery() {
           APM:
         </Trans>
       </p>
-      <SampleQuery nrql="SELECT **count(*)** FROM Transaction " fallbacknrql="SELECT count(*) FROM Public_APICall" span="6" />
-
+      <SampleQuery 
+        nrql="SELECT **count(*)** FROM Transaction " 
+        fallbacknrql="SELECT count(*) FROM Public_APICall" 
+        span="6" 
+      />
       <h2>
         <Trans i18nKey="Contents.H1">Lesson Summary</Trans>
       </h2>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Facet.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Facet.js
@@ -16,6 +16,7 @@ export default function Facet() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **FACET name** SINCE 1 day ago"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall FACET awsAPI SINCE 1 day ago"
         chartType="bar"
         span="6"
       />
@@ -29,6 +30,7 @@ export default function Facet() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **FACET name** SINCE 3 hours ago **LIMIT 5** TIMESERIES"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall FACET awsAPI SINCE 3 hours ago LIMIT 5 TIMESERIES"
         span="6"
       />
       <p>
@@ -40,11 +42,13 @@ export default function Facet() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **FACET name** SINCE 3 hours ago **LIMIT 20**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall FACET awsAPI SINCE 3 hours ago LIMIT 20"
         chartType="bar"
         span="6"
       />
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **FACET name** SINCE 3 hours ago **LIMIT 20**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall FACET awsAPI SINCE 3 hours ago LIMIT 20"
         chartType="pie"
         span="6"
       />
@@ -56,6 +60,7 @@ export default function Facet() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) FROM Transaction WHERE transactionType='Web' **FACET appName** LIMIT 5 SINCE 6 hours ago TIMESERIES"
+        fallbacknrql="SELECT count(*) FROM Public_APICall FACET awsAPI LIMIT 5 SINCE 6 hours ago TIMESERIES"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/FirstQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/FirstQuery.js
@@ -29,6 +29,7 @@ export default function FirstQuery() {
 
       <SampleQuery
         nrql="**SELECT** \* **FROM** Transaction"
+        fallbacknrql="SELECT * FROM Public_APICall"
         chartType="table"
         span="12"
       />
@@ -43,6 +44,7 @@ export default function FirstQuery() {
 
       <SampleQuery
         nrql="SELECT \* FROM Transaction **LIMIT 1**"
+        fallbacknrql="SELECT * FROM Public_APICall LIMIT 1"
         chartType="table"
         span="12"
       />
@@ -78,6 +80,7 @@ export default function FirstQuery() {
 
       <SampleQuery
         nrql="SELECT **name, duration** FROM Transaction "
+        fallbacknrql="SELECT api, duration FROM Public_APICall"
         chartType="table"
         span="12"
       />

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
@@ -40,8 +40,9 @@ export default function Overview() {
           customers will have this type of data.
           <strong>
             If you have access to more than one account, please switch to an
-            account using APM. If none of your accounts have APM data. We will use fallback queries. This may mean the lesson references
-            Transaction table. However the query may use another NR event to showcase a similar query.
+            account using APM. If none of your accounts have APM data. We will use fallback queries. 
+            This may mean the lesson references Transaction table. However the query may use another 
+            NR event to showcase a similar query.
           </strong>
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
@@ -40,9 +40,10 @@ export default function Overview() {
           customers will have this type of data.
           <strong>
             If you have access to more than one account, please switch to an
-            account using APM. If none of your accounts have APM data. We will use fallback queries. 
-            This may mean the lesson references Transaction table. However the query may use another 
-            NR event to showcase a similar query.
+            account using APM. If none of your accounts have APM data. We will 
+            use fallback queries. 
+            This may mean the lesson references Transaction table. However the query may use another NR event to
+            showcase a similar query.
           </strong>
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
@@ -41,8 +41,7 @@ export default function Overview() {
           <strong>
             If you have access to more than one account, please switch to an
             account using APM. If none of your accounts have APM data. We will
-            use fallback queries. 
-            This may mean the lesson references
+            use fallback queries. This may mean the lesson references
             Transaction table. However the query may use another NR event to
             showcase a similar query.
           </strong>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
@@ -40,7 +40,8 @@ export default function Overview() {
           customers will have this type of data.
           <strong>
             If you have access to more than one account, please switch to an
-            account using APM.
+            account using APM. If none of your accounts have APM data. We will use fallback queries. This may mean the lesson references
+            Transaction table. However the query may use another NR event to showcase a similar query.
           </strong>
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Overview.js
@@ -40,9 +40,10 @@ export default function Overview() {
           customers will have this type of data.
           <strong>
             If you have access to more than one account, please switch to an
-            account using APM. If none of your accounts have APM data. We will 
+            account using APM. If none of your accounts have APM data. We will
             use fallback queries. 
-            This may mean the lesson references Transaction table. However the query may use another NR event to
+            This may mean the lesson references
+            Transaction table. However the query may use another NR event to
             showcase a similar query.
           </strong>
         </Trans>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/TimeRange.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/TimeRange.js
@@ -40,22 +40,27 @@ export default function TimeRange() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **SINCE 1 day ago**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 day ago"
         span="6"
       />
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **SINCE 1 week ago UNTIL 2 days ago**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 week ago UNTIL 2 days ago"
         span="6"
       />
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **SINCE 23 hours ago UNTIL 15 minutes ago**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 23 hours ago UNTIL 15 minutes ago"
         span="6"
       />
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **SINCE today**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE today"
         span="6"
       />
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **SINCE this week**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE this week"
         span="6"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Timeseries.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Timeseries.js
@@ -28,6 +28,7 @@ export default function Timeseries() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction SINCE 1 day ago **TIMESERIES**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 day ago TIMESERIES"
         span="12"
       />
       <p>
@@ -41,6 +42,7 @@ export default function Timeseries() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction SINCE 1 day ago **TIMESERIES 1 hour**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 day ago TIMESERIES 1 hour"
         span="12"
       />
       <p>
@@ -56,6 +58,7 @@ export default function Timeseries() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction SINCE 1 day ago **TIMESERIES MAX**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 day ago TIMESERIES MAX"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Where.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/lessons/Where.js
@@ -23,6 +23,7 @@ export default function Where() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **WHERE transactionType='Web'** TIMESERIES"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall WHERE awsAPI='dynamodb' TIMESERIES"
         span="12"
       />
       <p>
@@ -42,6 +43,7 @@ export default function Where() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction WHERE transactionType='Web' **AND** duration < 0.1 **AND (**httpResponseCode=200 **OR** httpResponseCode=302**)** TIMESERIES"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall WHERE awsAPI='dynamodb' AND duration > 0.02 AND http.method = 'POST' OR http.method = 'HEAD' TIMESERIES"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/AggregateQuery2.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/AggregateQuery2.js
@@ -29,6 +29,7 @@ export default function AggregateQuery2() {
 
       <SampleQuery
         nrql="SELECT **uniqueCount(host)** FROM Transaction SINCE 1 day ago"
+        fallbacknrql="SELECT uniqueCount(http.url) FROM Public_APICall SINCE 1 day ago"
         span="6"
       />
 
@@ -48,6 +49,7 @@ export default function AggregateQuery2() {
 
       <SampleQuery
         nrql="SELECT **uniques(host)** FROM Transaction SINCE 1 day ago"
+        fallbacknrql="SELECT uniques(http.url) FROM Public_APICall SINCE 1 day ago"
         span="6"
         chartType="table"
       />
@@ -73,6 +75,7 @@ export default function AggregateQuery2() {
 
       <SampleQuery
         nrql="SELECT **latest(duration)** FROM Transaction WHERE transactionType = 'Web' SINCE 1 day ago"
+        fallbacknrql="SELECT latest(duration) FROM Public_APICall WHERE awsAPI = 'sqs' SINCE 1 day ago"
         span="6"
       />
 
@@ -89,6 +92,7 @@ export default function AggregateQuery2() {
 
       <SampleQuery
         nrql="SELECT **earliest(duration)** FROM Transaction WHERE transactionType = 'Web' SINCE 1 day ago"
+        fallbacknrql="SELECT earliest(duration) FROM Public_APICall WHERE awsAPI = 'sqs' SINCE 1 day ago"
         span="6"
       />
 
@@ -115,6 +119,7 @@ export default function AggregateQuery2() {
 
       <SampleQuery
         nrql="SELECT **percentage(count(*), WHERE duration > 0.1)** FROM Transaction SINCE 1 day ago"
+        fallbacknrql="SELECT percentage(count(*), WHERE duration > 0.1) FROM Public_APICall SINCE 1 day ago"
         span="6"
       />
 
@@ -137,6 +142,7 @@ export default function AggregateQuery2() {
 
       <SampleQuery
         nrql="SELECT **percentile(duration, 98)** FROM Transaction SINCE 1 day ago"
+        fallbacknrql="SELECT percentile(duration,98) FROM Public_APICall SINCE 1 day ago"
         span="6"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/BasicMath.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/BasicMath.js
@@ -25,6 +25,7 @@ export default function BasicMath() {
 
       <SampleQuery
         nrql="SELECT **duration - databaseDuration**, name FROM Transaction WHERE databaseDuration IS NOT NULL"
+        fallbacknrql="SELECT GigabytesIngestedBillable - GigabytesIngestedFree, metric  FROM NrMTDConsumption WHERE productLine IS NOT NULL"
         span="12"
         chartType="table"
       />
@@ -40,6 +41,7 @@ export default function BasicMath() {
 
       <SampleQuery
         nrql="SELECT **average(duration - databaseDuration)** FROM Transaction WHERE databaseDuration IS NOT NULL"
+        fallbacknrql="SELECT average(GigabytesIngestedBillable - GigabytesIngestedFree) FROM NrMTDConsumption WHERE GigabytesIngestedBillable IS NOT NULL"
         span="12"
       />
 
@@ -54,6 +56,7 @@ export default function BasicMath() {
 
       <SampleQuery
         nrql="SELECT **(average(duration) - average(databaseDuration)) / average(duration) \* 100** FROM Transaction WHERE databaseDuration IS NOT NULL"
+        fallbacknrql="SELECT average(GigabytesIngestedBillable - GigabytesIngestedFree) / unitPrice * 100 FROM NrMTDConsumption WHERE GigabytesIngestedBillable IS NOT NULL"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/CastingAs.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/CastingAs.js
@@ -16,6 +16,7 @@ export default function CastingAs() {
 
       <SampleQuery
         nrql="SELECT average(duration-externalDuration) from Transaction"
+        fallbacknrql="SELECT average(GigabytesIngestedBillable-GigabytesIngestedFree) FROM NrMTDConsumption"
         span="6"
       />
 
@@ -30,6 +31,7 @@ export default function CastingAs() {
 
       <SampleQuery
         nrql="SELECT average(duration-externalDuration) **AS 'Non-External Response Time'** from Transaction"
+        fallbacknrql="SELECT average(GigabytesIngestedBillable-GigabytesIngestedFree) AS 'GBs Ingested' FROM NrMTDConsumption"
         span="6"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/CompareWith.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/CompareWith.js
@@ -32,6 +32,7 @@ export default function CompareWith() {
 
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction SINCE 1 DAY AGO **COMPARE WITH 1 WEEK AGO**"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 day ago COMPARE WITH 1 week ago"
         span="6"
       />
 
@@ -46,6 +47,7 @@ export default function CompareWith() {
 
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction SINCE 1 DAY AGO **COMPARE WITH 1 WEEK AGO** TIMESERIES"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 day ago COMPARE WITH 1 week ago TIMESERIES"
         span="12"
       />
 
@@ -59,6 +61,7 @@ export default function CompareWith() {
 
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction SINCE 1 HOUR AGO **COMPARE WITH 6 HOURS AGO** TIMESERIES"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall SINCE 1 hour ago COMPARE WITH 6 hours ago TIMESERIES"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
@@ -27,7 +27,9 @@ export default function Overview() {
       </p>
 
       <p>
-        <Trans i18nKey="Contents.P3">Again if you have chosen an account without Transaction event reporting, we will fallback to other queries that are similar. Let's get started!</Trans>
+        <Trans i18nKey="Contents.P3">Again if you have chosen an account without Transaction event 
+        reporting, we will fallback to other queries that are similar. Let's 
+        get started!</Trans>
       </p>
     </div>
   );

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
@@ -28,8 +28,8 @@ export default function Overview() {
 
       <p>
         <Trans i18nKey="Contents.P3">
-          Again if you have chosen an account without Transaction event 
-          reporting, we will fallback to other queries that are similar. Let's 
+          Again if you have chosen an account without Transaction event
+          reporting, we will fallback to other queries that are similar. Let's
           get started!
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
@@ -27,7 +27,7 @@ export default function Overview() {
       </p>
 
       <p>
-        <Trans i18nKey="Contents.P3">Let's get started!</Trans>
+        <Trans i18nKey="Contents.P3">Again if you have chosen an account without Transaction event reporting, we will fallback to other queries that are similar. Let's get started!</Trans>
       </p>
     </div>
   );

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Overview.js
@@ -27,9 +27,11 @@ export default function Overview() {
       </p>
 
       <p>
-        <Trans i18nKey="Contents.P3">Again if you have chosen an account without Transaction event 
-        reporting, we will fallback to other queries that are similar. Let's 
-        get started!</Trans>
+        <Trans i18nKey="Contents.P3">
+          Again if you have chosen an account without Transaction event 
+          reporting, we will fallback to other queries that are similar. Let's 
+          get started!
+        </Trans>
       </p>
     </div>
   );

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeBasedCohorting.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeBasedCohorting.js
@@ -34,6 +34,7 @@ export default function TimeBasedCohorting() {
 
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **FACET hourOf(timestamp)** SINCE 1 week ago"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall FACET hourOf(timestamp) SINCE 1 week ago"
         span="12"
       />
       <p>
@@ -53,6 +54,7 @@ export default function TimeBasedCohorting() {
 
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **FACET weekdayOf(timestamp)** SINCE 1 week ago"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall FACET weekdayOf(timestamp) SINCE 1 week ago"
         span="12"
       />
       <p>
@@ -73,6 +75,7 @@ export default function TimeBasedCohorting() {
 
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction **FACET dateOf(timestamp)** SINCE 1 week ago"
+        fallbacknrql="SELECT average(duration) FROM Public_APICall FACET dateOf(timestamp) SINCE 1 week ago"
         span="12"
       />
       <h2>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
@@ -29,11 +29,7 @@ export default function TimeRangesAdvanced() {
           SLA reports for a specified period of time.
         </Trans>
       </p>
-      <SampleQuery
-        nrql={timedNRQL}
-        fallbacknrql={fbtimedNRQL}
-        span="12"
-      />
+      <SampleQuery nrql={timedNRQL} fallbacknrql={fbtimedNRQL} span="12" />
       <p>
         <Trans i18nKey="Contents.P2">
           You can even include specific time with the format{' '}
@@ -57,11 +53,7 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery
-        nrql={epochNRQL}
-        fallbacknrql={fbepochNRQL}
-        span="12"
-      />
+      <SampleQuery nrql={epochNRQL} fallbacknrql={fbepochNRQL} span="12" />
 
       <p>
         <Trans i18nKey="Contents.P4">

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
@@ -42,10 +42,10 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery 
-        nrql={timedNRQLTime} 
-        fallbacknrql={fbtimedNRQLTime} 
-        span="12" 
+      <SampleQuery
+        nrql={timedNRQLTime}
+        fallbacknrql={fbtimedNRQLTime}
+        span="12"
       />
 
       <p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
@@ -29,8 +29,8 @@ export default function TimeRangesAdvanced() {
           SLA reports for a specified period of time.
         </Trans>
       </p>
-      <SampleQuery 
-        nrql={timedNRQL} fallbacknrql={fbtimedNRQL} span="12" 
+      <SampleQuery
+        nrql={timedNRQL} fallbacknrql={fbtimedNRQL} span="12"
       />
       <p>
         <Trans i18nKey="Contents.P2">
@@ -41,9 +41,7 @@ export default function TimeRangesAdvanced() {
       </p>
 
       <SampleQuery
-        nrql={timedNRQLTime}
-        fallbacknrql={fbtimedNRQLTime}
-        span="12"
+        nrql={timedNRQLTime} fallbacknrql={fbtimedNRQLTime} span="12"
       />
 
       <p>
@@ -55,7 +53,7 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery 
+      <SampleQuery
         nrql={epochNRQL} fallbacknrql={fbepochNRQL} span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
@@ -10,9 +10,12 @@ const sevendaysago = epochSince.toLocaleDateString('fr-CA', {
   day: '2-digit'
 });
 const timedNRQL = `SELECT average(duration) FROM Transaction **SINCE '${sevendaysago}'** TIMESERIES MAX`;
+const fbtimedNRQL= `SELECT average(duration) FROM Public_APICall SINCE '${sevendaysago}' TIMESERIES MAX`;
 const timedNRQLTime = `SELECT average(duration) FROM Transaction **SINCE '${sevendaysago} 18:00'** TIMESERIES MAX`;
+const fbtimedNRQLTime = `SELECT average(duration) FROM Public_APICall SINCE '${sevendaysago} 18:00' TIMESERIES MAX`;
 const epochUntil = new Date();
 const epochNRQL = `SELECT average(duration) FROM Transaction **SINCE ${epochSince.getTime()} UNTIL ${epochUntil.getTime()}** TIMESERIES MAX`;
+const fbepochNRQL = `SELECT average(duration) FROM Public_APICall SINCE ${epochSince.getTime()} UNTIL ${epochUntil.getTime()} TIMESERIES MAX`;
 
 export default function TimeRangesAdvanced() {
   return (
@@ -27,7 +30,7 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery nrql={timedNRQL} span="12" />
+      <SampleQuery nrql={timedNRQL} fallbacknrql={fbtimedNRQL}  span="12" />
 
       <p>
         <Trans i18nKey="Contents.P2">
@@ -37,7 +40,7 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery nrql={timedNRQLTime} span="12" />
+      <SampleQuery nrql={timedNRQLTime} fallbacknrql={fbtimedNRQLTime} span="12" />
 
       <p>
         <Trans i18nKey="Contents.P3">
@@ -48,7 +51,7 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery nrql={epochNRQL} span="12" />
+      <SampleQuery nrql={epochNRQL} fallbacknrql={fbepochNRQL} span="12" />
 
       <p>
         <Trans i18nKey="Contents.P4">
@@ -77,10 +80,12 @@ export default function TimeRangesAdvanced() {
 
       <SampleQuery
         nrql="SELECT count(\*) from Transaction since yesterday until today **WITH TIMEZONE 'America/Los_Angeles'** TIMESERIES"
+        fallbacknrql="SELECT count(*) FROM Public_APICall SINCE yesterday until today WITH TIMEZONE 'America/Los_Angeles' TIMESERIES"
         span="12"
       />
       <SampleQuery
         nrql="SELECT count(\*) from Transaction since yesterday until today **WITH TIMEZONE 'Europe/London'** TIMESERIES"
+        fallbacknrql="SELECT count(*) FROM Public_APICall SINCE yesterday until today WITH TIMEZONE 'Europe/London' TIMESERIES"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
@@ -10,7 +10,7 @@ const sevendaysago = epochSince.toLocaleDateString('fr-CA', {
   day: '2-digit'
 });
 const timedNRQL = `SELECT average(duration) FROM Transaction **SINCE '${sevendaysago}'** TIMESERIES MAX`;
-const fbtimedNRQL= `SELECT average(duration) FROM Public_APICall SINCE '${sevendaysago}' TIMESERIES MAX`;
+const fbtimedNRQL = `SELECT average(duration) FROM Public_APICall SINCE '${sevendaysago}' TIMESERIES MAX`;
 const timedNRQLTime = `SELECT average(duration) FROM Transaction **SINCE '${sevendaysago} 18:00'** TIMESERIES MAX`;
 const fbtimedNRQLTime = `SELECT average(duration) FROM Public_APICall SINCE '${sevendaysago} 18:00' TIMESERIES MAX`;
 const epochUntil = new Date();
@@ -29,9 +29,11 @@ export default function TimeRangesAdvanced() {
           SLA reports for a specified period of time.
         </Trans>
       </p>
-
-      <SampleQuery nrql={timedNRQL} fallbacknrql={fbtimedNRQL}  span="12" />
-
+      <SampleQuery 
+        nrql={timedNRQL} 
+        fallbacknrql={fbtimedNRQL}  
+        span="12" 
+      />
       <p>
         <Trans i18nKey="Contents.P2">
           You can even include specific time with the format{' '}
@@ -40,7 +42,11 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery nrql={timedNRQLTime} fallbacknrql={fbtimedNRQLTime} span="12" />
+      <SampleQuery 
+        nrql={timedNRQLTime} 
+        fallbacknrql={fbtimedNRQLTime} 
+        span="12" 
+      />
 
       <p>
         <Trans i18nKey="Contents.P3">
@@ -51,7 +57,11 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
 
-      <SampleQuery nrql={epochNRQL} fallbacknrql={fbepochNRQL} span="12" />
+      <SampleQuery 
+        nrql={epochNRQL} 
+        fallbacknrql={fbepochNRQL} 
+        span="12"
+      />
 
       <p>
         <Trans i18nKey="Contents.P4">

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
@@ -30,7 +30,9 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
       <SampleQuery
-        nrql={timedNRQL} fallbacknrql={fbtimedNRQL} span="12"
+        nrql={timedNRQL}
+        fallbacknrql={fbtimedNRQL}
+        span="12"
       />
       <p>
         <Trans i18nKey="Contents.P2">
@@ -41,7 +43,9 @@ export default function TimeRangesAdvanced() {
       </p>
 
       <SampleQuery
-        nrql={timedNRQLTime} fallbacknrql={fbtimedNRQLTime} span="12"
+        nrql={timedNRQLTime}
+        fallbacknrql={fbtimedNRQLTime}
+        span="12"
       />
 
       <p>
@@ -54,7 +58,9 @@ export default function TimeRangesAdvanced() {
       </p>
 
       <SampleQuery
-        nrql={epochNRQL} fallbacknrql={fbepochNRQL} span="12"
+        nrql={epochNRQL}
+        fallbacknrql={fbepochNRQL}
+        span="12"
       />
 
       <p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/TimeRangesAdvanced.js
@@ -30,9 +30,7 @@ export default function TimeRangesAdvanced() {
         </Trans>
       </p>
       <SampleQuery 
-        nrql={timedNRQL} 
-        fallbacknrql={fbtimedNRQL}  
-        span="12" 
+        nrql={timedNRQL} fallbacknrql={fbtimedNRQL} span="12" 
       />
       <p>
         <Trans i18nKey="Contents.P2">
@@ -58,9 +56,7 @@ export default function TimeRangesAdvanced() {
       </p>
 
       <SampleQuery 
-        nrql={epochNRQL} 
-        fallbacknrql={fbepochNRQL} 
-        span="12"
+        nrql={epochNRQL} fallbacknrql={fbepochNRQL} span="12"
       />
 
       <p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Wildcards.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level2/lessons/Wildcards.js
@@ -25,6 +25,7 @@ export default function Wildcards() {
 
       <SampleQuery
         nrql="SELECT count(\*) FROM Transaction WHERE name **LIKE '%Web%'** FACET name SINCE 1 day ago"
+        fallbacknrql="SELECT count(*) FROM Public_APICall WHERE http.url LIKE '%amazonaws%' FACET http.url SINCE 1 day ago"
         span="6"
       />
 
@@ -39,6 +40,7 @@ export default function Wildcards() {
 
       <SampleQuery
         nrql="SELECT count(\*) FROM Transaction WHERE name **NOT LIKE '%Web%'** FACET name SINCE 1 day ago"
+        fallbacknrql="SELECT count(*) FROM Public_APICall WHERE http.url NOT LIKE '%google%' FACET http.url SINCE 1 day ago"
         span="6"
       />
 
@@ -64,6 +66,7 @@ export default function Wildcards() {
 
       <SampleQuery
         nrql="SELECT count(\*) FROM Transaction WHERE name **LIKE '%Web%index%'** FACET name SINCE 1 day ago"
+        fallbacknrql="SELECT count(*) FROM Public_APICall WHERE http.url NOT LIKE '%amazon%.com' FACET http.url SINCE 1 day ago"
         span="6"
       />
 
@@ -91,6 +94,7 @@ export default function Wildcards() {
 
       <SampleQuery
         nrql="SELECT count(\*) FROM Transaction WHERE transactionSubType **IN ('SpringController', 'StrutsAction')** SINCE 1 day ago"
+        fallbacknrql="SELECT count(*) FROM Public_APICall WHERE http.url IN ('graph.microsoft.com', 's3.amazonaws.com') SINCE 1 day ago"
         span="6"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/AggregateQuery3.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/AggregateQuery3.js
@@ -46,6 +46,7 @@ export default function AggregateQuery3() {
       </p>
       <SampleQuery
         nrql="SELECT **rate(count(*), 5 minutes)** from Transaction SINCE 1 hour ago COMPARE WITH 1 hour ago"
+        fallbacknrql="SELECT rate(count(*), 5 minutes) FROM Public_APICall SINCE 1 hour ago COMPARE WITH 1 hour ago"
         span="6"
       />
 
@@ -84,6 +85,7 @@ export default function AggregateQuery3() {
       </p>
       <SampleQuery
         nrql="SELECT **funnel(session, WHERE pageUrl LIKE 'http%//%.%.com/' AS 'Home', WHERE pageUrl NOT LIKE 'http%//%.%.com/' AS 'Any Other Page')** FROM PageView SINCE 1 week ago UNTIL now"
+        fallbacknrql="SELECT funnel(awsAPI, WHERE http.url LIKE '%.amazonaws.com', WHERE http.url LIKE '%.us-west%.amazonaws.com') FROM Public_APICall SINCE 1 week ago UNTIL now"
         chartType="funnel"
         span="6"
       />
@@ -102,6 +104,7 @@ export default function AggregateQuery3() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) as 'All Transactions', **filter(count(\*), where transactionType ='Web') as 'Web Transactions'**, filter(count(\*), where transactionType !='Web') as 'Non-Web Transactions' from Transaction since 24 hours ago"
+        fallbacknrql="SELECT count(*) AS 'All Transactions', filter(count(*), WHERE awsAPI = 'dynamodb') AS 'DynamoDB', filter(count(*), WHERE awsAPI = 'sqs') AS 'SQS' FROM Public_APICall SINCE 1 day ago"
         span="12"
       />
 
@@ -114,6 +117,7 @@ export default function AggregateQuery3() {
       </p>
       <SampleQuery
         nrql="SELECT (filter(count(\*), where transactionType ='Web') **/ count(\*)) \* 100**  as 'Percent web' from Transaction since 24 hours ago"
+        fallbacknrql="SELECT filter(count(*), WHERE awsAPI = 'dynamodb') / count(*) AS 'Percent of APIs that are DynamoDB' FROM Public_APICall SINCE 1 day ago"
         span="6"
       />
 
@@ -144,6 +148,7 @@ export default function AggregateQuery3() {
 
       <SampleQuery
         nrql="SELECT **histogram(duration, 1, 20)** from Transaction since 24 hours ago"
+        fallbacknrql="SELECT histogram(duration, 1, 20) FROM Public_APICall SINCE 1 day ago"
         chartType="histogram"
         span="12"
       />
@@ -163,6 +168,7 @@ export default function AggregateQuery3() {
       </p>
       <SampleQuery
         nrql="SELECT **apdex(duration, t: 0.08) as 'Apdex of Duration'** FROM Transaction SINCE 1 week ago"
+        fallbacknrql="SELECT apdex(duration, 0.1) AS 'Apdex Of Duration' FROM Public_APICall SINCE 1 week ago"
         span="12"
       />
 
@@ -175,6 +181,7 @@ export default function AggregateQuery3() {
       </p>
       <SampleQuery
         nrql="SELECT apdex(duration, t: 0.08) as 'Apdex of Duration' FROM Transaction SINCE 1 week ago **TIMESERIES**"
+        fallbacknrql="SELECT apdex(duration, 0.1) AS 'Apdex Of Duration' FROM Public_APICall SINCE 1 week ago TIMESERIES"
         span="6"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
@@ -24,9 +24,9 @@ export default function Extrapolate() {
           compensate for the effects of sampling, thereby returning results that
           more closely represent activity in your system. We store an extra
           value to record how many similar events occured over the limit. This
-          allows New Relic to deliver statistically accurate results. 
-          There is no fallback query for this if you have no APM data
-          due to the fact this is specific to Transaction events.
+          allows New Relic to deliver statistically accurate results. There is 
+          no fallback query for this if you have no APM data due to the fact 
+          this is specific to Transaction events.
         </Trans>
       </p>
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
@@ -24,7 +24,8 @@ export default function Extrapolate() {
           compensate for the effects of sampling, thereby returning results that
           more closely represent activity in your system. We store an extra
           value to record how many similar events occured over the limit. This
-          allows New Relic to deliver statistically accurate results. There is no fallback query for this if you have no APM data
+          allows New Relic to deliver statistically accurate results. 
+          There is no fallback query for this if you have no APM data
           due to the fact this is specific to Transaction events.
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
@@ -24,8 +24,8 @@ export default function Extrapolate() {
           compensate for the effects of sampling, thereby returning results that
           more closely represent activity in your system. We store an extra
           value to record how many similar events occured over the limit. This
-          allows New Relic to deliver statistically accurate results. There is 
-          no fallback query for this if you have no APM data due to the fact 
+          allows New Relic to deliver statistically accurate results. There is
+          no fallback query for this if you have no APM data due to the fact
           this is specific to Transaction events.
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Extrapolate.js
@@ -24,12 +24,14 @@ export default function Extrapolate() {
           compensate for the effects of sampling, thereby returning results that
           more closely represent activity in your system. We store an extra
           value to record how many similar events occured over the limit. This
-          allows New Relic to deliver statistically accurate results.
+          allows New Relic to deliver statistically accurate results. There is no fallback query for this if you have no APM data
+          due to the fact this is specific to Transaction events.
         </Trans>
       </p>
 
       <SampleQuery
         nrql="SELECT count(\*) FROM Transaction SINCE 60 minutes ago FACET appName TIMESERIES 1 minute **EXTRAPOLATE**"
+        fallbacknrql="SELECT count(*) FROM Transaction SINCE 60 minutes ago FACET appName TIMESERIES 1 minute EXTRAPOLATE"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/FacetCases.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/FacetCases.js
@@ -30,6 +30,7 @@ export default function FacetCases() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) from Transaction **FACET CASES(where response.status LIKE '2%' OR httpResponseCode LIKE '2%', where response.status LIKE '3%' OR httpResponseCode LIKE '3%', where response.status LIKE '4%' OR httpResponseCode LIKE '4%', where response.status LIKE '5%' OR httpResponseCode LIKE '5%')**"
+        fallbacknrql="SELECT count(*) FROM Public_APICall FACET CASES(WHERE http.url LIKE '%amazon%', WHERE http.url LIKE '%google%', WHERE http.url LIKE '%microsoft%')"
         span="12"
       />
       <p>
@@ -41,6 +42,7 @@ export default function FacetCases() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) from Transaction FACET CASES(where response.status LIKE '2%' OR httpResponseCode LIKE '2%' **as '2xx Responses'**, where response.status LIKE '3%' OR httpResponseCode LIKE '3%' **as '3xx Responses'**, where response.status LIKE '4%' OR httpResponseCode LIKE '4%' **as '4xx Responses'**, where response.status LIKE '5%' OR httpResponseCode LIKE '5%' **as '5xx Responses'**)"
+        fallbacknrql="SELECT count(*) FROM Public_APICall FACET CASES(WHERE http.url LIKE '%amazon%' AS 'Amazon', WHERE http.url LIKE '%google%' AS 'Google', WHERE http.url LIKE '%microsoft%' AS 'Microsoft')"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/FilterToEventTypes.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/FilterToEventTypes.js
@@ -23,6 +23,7 @@ export default function FilterToEventTypes() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) as 'Combined Events' **FROM Transaction, PageView** SINCE  1 day ago"
+        fallbacknrql="SELECT count(*) AS 'Combined Events' FROM Public_APICall, NrMTDConsumption SINCE 1 day ago"
         span="6"
       />
 
@@ -37,6 +38,7 @@ export default function FilterToEventTypes() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) as 'Combined Events', filter(count(\*), **WHERE eventType() = 'PageView'**) as 'Page Views', filter(count(\*), **WHERE eventType()='Transaction'**) as 'Transactions' FROM Transaction, PageView SINCE  1 day ago"
+        fallbacknrql="SELECT count(*) AS 'Combined Events', filter(count(*), WHERE eventType() = 'Public_APICall') as 'Public_APICall', filter(count(*), WHERE eventType()='NrMTDConsumption') as 'NrMTDConsumption' FROM Public_APICall, NrMTDConsumption SINCE 1 day ago"
         span="12"
       />
 
@@ -56,6 +58,7 @@ export default function FilterToEventTypes() {
 
       <SampleQuery
         nrql="SELECT count(\*) as 'Combined Events', filter(count(\*), WHERE eventType() = 'PageView') as 'Page Views', filter(count(\*), WHERE eventType()='Transaction') as 'Transactions' FROM Transaction, PageView SINCE  1 day ago TIMESERIES max"
+        fallbacknrql="SELECT count(*) AS 'Combined Events', filter(count(*), WHERE eventType() = 'Public_APICall') as 'Public_APICall', filter(count(*), WHERE eventType()='NrMTDConsumption') as 'NrMTDConsumption' FROM Public_APICall, NrMTDConsumption SINCE 1 day ago TIMESERIES max"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/OverridingValues.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/OverridingValues.js
@@ -41,6 +41,7 @@ export default function OverridingValues() {
       </p>
       <SampleQuery
         nrql="SELECT count(apdexPerfZone) as 'Events With Values', count(apdexPerfZone **OR 'Null'**) as 'Events With and Without Values' from Transaction since 24 hours ago"
+        fallbacknrql="SELECT count(duration) AS 'Events With Durations', count(http.url OR 'Null') AS Events With and Without URL' FROM Public_APICall SINCE 1 day ago"
         span="12"
       />
 
@@ -63,6 +64,7 @@ export default function OverridingValues() {
       </p>
       <SampleQuery
         nrql="SELECT average(**numeric(httpResponseCode)**) as 'Converted Attribute', average(httpResponseCode) as 'Non-converted Attribute'  from Transaction since 24 hours ago"
+        fallbacknrql="SELECT average(numeric(duration)) AS 'Ensuring stored value is treated as numeric', average(duration) AS 'Non-Converted Attribute' FROM Public_APICall SINCE 1 day ago"
         span="12"
       />
 
@@ -80,6 +82,7 @@ export default function OverridingValues() {
       </p>
       <SampleQuery
         nrql="SELECT count(boolean(error)), count(error)  from Transaction since 24 hours ago"
+        fallbacknrql="SELECT count(boolean(sampleDataSet)), count(sampleDataSet)  from Public_APICall since 24 hours ago"
         span="12"
       />
       <h2>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Overview.js
@@ -25,8 +25,8 @@ export default function Overview() {
         <Trans i18nKey="Contents.P3">
           In this level, we will cover faceting by case, advanced aggregation
           functions, the value of the EXTRAPOLATE keyword, filtering aggregation
-          functions, and how to override values. Remember if you've chosen an 
-          account without APM data. You will see backup queries that may not 
+          functions, and how to override values. Remember if you've chosen an
+          account without APM data. You will see backup queries that may not
           match the lesson description.
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Overview.js
@@ -25,7 +25,9 @@ export default function Overview() {
         <Trans i18nKey="Contents.P3">
           In this level, we will cover faceting by case, advanced aggregation
           functions, the value of the EXTRAPOLATE keyword, filtering aggregation
-          functions, and how to override values. Remember if you've chosen an account without APM data. You will see backup queries that may not match the lesson description.
+          functions, and how to override values. Remember if you've chosen an 
+          account without APM data. You will see backup queries that may not 
+          match the lesson description.
         </Trans>
       </p>
     </div>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/Overview.js
@@ -25,7 +25,7 @@ export default function Overview() {
         <Trans i18nKey="Contents.P3">
           In this level, we will cover faceting by case, advanced aggregation
           functions, the value of the EXTRAPOLATE keyword, filtering aggregation
-          functions, and how to override values.
+          functions, and how to override values. Remember if you've chosen an account without APM data. You will see backup queries that may not match the lesson description.
         </Trans>
       </p>
     </div>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/AdvancedMath.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/AdvancedMath.js
@@ -45,6 +45,7 @@ export default function AdvancedMath() {
       </p>
       <SampleQuery
         nrql="SELECT **abs(duration)**, **round(duration)**, **ceil(duration)**, **floor(duration)** FROM Transaction SINCE 1 day ago"
+        fallbacknrql="SELECT abs(duration), round(duration), ceil(duration), floor(duration) from Public_APICall since 24 hours ago"
         chartType="table"
         span="12"
       />
@@ -66,6 +67,7 @@ export default function AdvancedMath() {
       </p>
       <SampleQuery
         nrql="SELECT **clamp\_max(average(duration), 10)**, **clamp\_min(average(duration), 1)** FROM Transaction SINCE 1 day ago TIMESERIES"
+        fallbacknrql="SELECT clamp_max(average(duration), 10), clamp_min(average(duration), 1) from Public_APICall since 24 hours ago TIMESERIES"
         span="12"
       />
 
@@ -117,6 +119,7 @@ export default function AdvancedMath() {
 
       <SampleQuery
         nrql="SELECT **pow(duration, 2)**, **sqrt(duration)**, **exp(duration)**, **ln(duration)**, **log2(duration)** FROM Transaction SINCE 1 day ago"
+        fallbacknrql="SELECT pow(duration, 2), sqrt(duration), exp(duration), ln(duration), log2(duration) from Public_APICall since 24 hours ago"
         chartType="table"
         span="12"
       />

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/AggregateQuery4.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/AggregateQuery4.js
@@ -29,6 +29,7 @@ export default function AggregateQuery4() {
       </p>
       <SampleQuery
         nrql="SELECT **stddev(duration)** from Transaction since 24 hours ago COMPARE WITH 24 hours ago TIMESERIES "
+        fallbacknrql="SELECT stddev(duration) from Public_APICall since 24 hours ago COMPARE WITH 24 hours ago TIMESERIES"
         span="12"
       />
 
@@ -80,6 +81,7 @@ export default function AggregateQuery4() {
       </p>
       <SampleQuery
         nrql="SELECT average(duration) FROM Transaction SINCE 12 hours ago FACET **buckets(databaseCallCount, 400, 10)**"
+        fallbacknrql="SELECT average(duration) from Public_APICall since 24 hours ago FACET buckets(duration, 400, 10)"
         span="12"
       />
       <h2>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/DiscoverEventsAndAttributes.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/DiscoverEventsAndAttributes.js
@@ -29,6 +29,7 @@ export default function DiscoverEventsAndAttributes() {
       </p>
       <SampleQuery
         nrql="**SHOW EVENT TYPES** SINCE 1 week ago"
+        fallbacknrql="SHOW EVENT TYPES SINCE 1 week ago"
         chartType="json"
         span="12"
       />
@@ -49,6 +50,7 @@ export default function DiscoverEventsAndAttributes() {
       </p>
       <SampleQuery
         nrql="SELECT **keyset()** FROM Transaction SINCE 1 week ago"
+        fallbacknrql="SHOW keyset() FROM Public_APICall SINCE 1 week ago"
         chartType="json"
         span="12"
       />

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
@@ -16,7 +16,7 @@ export default function Overview() {
           This next section will discuss additional aggregation techniques,
           higher-level math functions, and advanced features like Regex
           filtering, and nested aggregation. We think you'll find these features
-          downright invaluable. Let's get started!
+          downright invaluable. Let's get started! (Remember if your account doesn't have Transaction event data the queries will fall back to safer queries)
         </Trans>
       </p>
     </div>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
@@ -16,7 +16,8 @@ export default function Overview() {
           This next section will discuss additional aggregation techniques,
           higher-level math functions, and advanced features like Regex
           filtering, and nested aggregation. We think you'll find these features
-          downright invaluable. Let's get started! (Remember if your account doesn't have Transaction event data the queries will fall back to safer queries)
+          downright invaluable. Let's get started! (Remember if your account doesn't
+           have Transaction event data the queries will fall back to safer queries)
         </Trans>
       </p>
     </div>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
@@ -16,8 +16,8 @@ export default function Overview() {
           This next section will discuss additional aggregation techniques,
           higher-level math functions, and advanced features like Regex
           filtering, and nested aggregation. We think you'll find these features
-          downright invaluable. Let's get started! (Remember if your account 
-          doesn't have Transaction event data the queries will fall back to 
+          downright invaluable. Let's get started! (Remember if your account
+          doesn't have Transaction event data the queries will fall back to
           safer queries)
         </Trans>
       </p>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Overview.js
@@ -16,8 +16,9 @@ export default function Overview() {
           This next section will discuss additional aggregation techniques,
           higher-level math functions, and advanced features like Regex
           filtering, and nested aggregation. We think you'll find these features
-          downright invaluable. Let's get started! (Remember if your account doesn't
-           have Transaction event data the queries will fall back to safer queries)
+          downright invaluable. Let's get started! (Remember if your account 
+          doesn't have Transaction event data the queries will fall back to 
+          safer queries)
         </Trans>
       </p>
     </div>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/SubQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/SubQuery.js
@@ -47,6 +47,7 @@ export default function SubQuery() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) **AS rpm** FROM Transaction TIMESERIES 1 MINUTE"
+        fallbacknrql="SELECT count(*) AS apicalls FROM Public_APICall TIMESERIES 1 minute"
         span="12"
       />
       <p>
@@ -58,6 +59,7 @@ export default function SubQuery() {
       </p>
       <SampleQuery
         nrql="**SELECT max(rpm) FROM (**SELECT count(\*) **AS rpm** FROM Transaction TIMESERIES 1 MINUTE**)**"
+        fallbacknrql="SELECT max(apicalls) FROM (SELECT count(*) AS apicalls FROM Public_APICall TIMESERIES 1 minute)"
         span="6"
         chartType="table"
       />
@@ -92,6 +94,7 @@ export default function SubQuery() {
       </p>
       <SampleQuery
         nrql="SELECT hostname, **cpu** FROM (SELECT average(cpuPercent) **AS cpu** FROM SystemSample FACET hostname) **WHERE cpu > 20**"
+        fallbacknrql="SELECT api, slowAPIDuration FROM (SELECT average(duration) AS slowAPIDuration FROM Public_APICall FACET api) WHERE slowAPIDuration > 1"
         span="12"
         chartType="table"
       />
@@ -114,6 +117,7 @@ export default function SubQuery() {
       </p>
       <SampleQuery
         nrql="SELECT percentage(count(\*), **WHERE sessionLength = 1**) FROM (SELECT count(\*) **AS sessionLength** FROM PageView FACET session)"
+        fallbacknrql="SELECT percentage(count(*), WHERE slowAPIDuration > 1) FROM (SELECT average(duration) AS slowAPIDuration FROM Public_APICall FACET api)"
         span="12"
       />
 

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/UsingRegex.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/UsingRegex.js
@@ -24,6 +24,7 @@ export default function UsingRegex() {
       </p>
       <SampleQuery
         nrql="SELECT uniques(host) FROM Transaction WHERE host **RLIKE '^.\*\[02468bcdfghjklmnpqrstvwxyz]'**"
+        fallbacknrql="SELECT uniques(http.url) FROM Public_APICall WHERE http.url  RLIKE '^.*[02468bcdfghjklmnpqrstvwxyz]'"
         chartType="table"
         span="6"
       />
@@ -36,6 +37,7 @@ export default function UsingRegex() {
       </p>
       <SampleQuery
         nrql="SELECT count(\*) FROM Transaction WHERE name **RLIKE 'W.\*|O.\*'** FACET name"
+        fallbacknrql="SELECT count(*) FROM Public_APICall WHERE http.url  RLIKE 'sqs.*|dynamodb.*'"
         span="6"
       />
       <p>


### PR DESCRIPTION
This is an update to the nerdpack that based on the Account selected if it has recent APM data it uses the regular queries, but if no APM data it will fallback to queries using NR Account based events like NrMTDConsumption , Public_APICall to give different example queries that will return data despite the lack of APM data.