### PR TITLE
Added i18n namespace for NRQL

### DIFF
--- a/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
+++ b/nerdlets/nrql-tutorial-nerdlet/components/SampleQuery.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { LessonContextConsumer } from '../contexts/LessonContext';
 import copy from 'copy-to-clipboard';
+import { Trans } from 'react-i18next';
 
 import {
   LineChart,
@@ -111,8 +112,12 @@ export default class SampleQuery extends React.Component {
           if(context.hasNoAPM) {
             nrql = fallbacknrql;
             nrqlPlain = fallbacknrqlPlain;
-            fallBackDescription=<div className="fallBackNote">⚠️ Using fallback NRQL query example, this may differ slightly from the description.</div>
-
+            fallBackDescription=<div className="fallBackNote">⚠️
+                <Trans i18nKey="NRQL:Warn">
+                  Using fallback NRQL query example, this may differ slightly
+                  from the description. English
+                </Trans>
+              </div>
           }
           return (
             <Grid className="sample-query">

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level1/locales/ja.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level1/locales/ja.js
@@ -1,4 +1,8 @@
 const translate = {
+  NRQL: {
+    Warn:
+      'Using fallback NRQL query example, this may differ slightly from the description.'
+  },
   'Level One': {
     Title: 'コツを掴む',
     Level: 'レベル1 : '


### PR DESCRIPTION
Added a new i18n namespace 'NRQL' which allows for the translation of the warning about the fallback NRQL statement being used with each chart.