### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd nr1-learn-nrql
 npm install
 nr1 nerdpack:uuid -gf
 nr1 nerdpack:publish
-nr1 nerdpack:subscribe  -C STABLE
+nr1 nerdpack:subscribe -c STABLE
 ```
 This last command will subscribe the application to the account you've set as your default profile. You can check this using `nr1 profiles:default`. If you're not ready to deploy it to your account or want to test out changes you've made locally you can use:
 


### PR DESCRIPTION
Procedure for installation had a problem:
```
% nr1 nerdpack:subscribe  -C STABLE

 ›   Error: Unexpected arguments: -C, STABLE
 ›   See more help with --help
 ›   Code: UNKNOWN
```

The reason is that the `nr1 nerdpack:subscribe` command requires a **lowercase** -c as parameter