### PR TITLE
Minor updates to support Transaction events in remaining query examples

### DIFF
--- a/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/IfThen.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level3/lessons/IfThen.js
@@ -13,8 +13,8 @@ export default function IfThen() {
       </p>
 
       <SampleQuery
-        nrql="FROM Public_APICall select count(\*), **IF(count(\*)> 1000000,'High traffic','Low traffic') as 'Scale'** FACET api "
-        fallbacknrql="FROM Public_APICall select count(\*), **IF(count(\*)> 1000000,'High traffic','Low traffic') as 'Scale'** FACET api"
+        nrql="FROM Transaction SELECT COUNT(\*), **IF(COUNT(\*)> 1000000,'High traffic','Low traffic') AS 'Scale'** FACET request.headers.host"
+        fallbacknrql="FROM Public_APICall SELECT COUNT(\*), **IF(COUNT(\*)> 1000000,'High traffic','Low traffic') AS 'Scale'** FACET api"
         chartType="table"
         span="12"
       />
@@ -26,8 +26,8 @@ export default function IfThen() {
         </Trans>
       </p>
       <SampleQuery
-        nrql="FROM Public_APICall select average(duration), **IF(average(duration)> 1,'🔴','🟢') as 'Flag'** FACET api"
-        fallbacknrql="FROM Public_APICall select  average(duration), **IF(average(duration)> 1,'🔴','🟢') as 'Flag'** FACET api"
+        nrql="FROM Transaction SELECT average(duration), **IF(average(duration)> 1,'🔴','🟢') AS 'Flag'** FACET request.headers.host"
+        fallbacknrql="FROM Public_APICall SELECT average(duration), **IF(average(duration)> 1,'🔴','🟢') AS 'Flag'** FACET api"
         chartType="table"
         span="12"
       />
@@ -39,8 +39,8 @@ export default function IfThen() {
         </Trans>
       </p>
       <SampleQuery
-        nrql="FROM Public_APICall SELECT count(*) **FACET IF(api like 'amazon%', 'Amazon', if(api like 'google%', 'Google','Everything else')) AS 'Service'**"
-        fallbacknrql="FROM Public_APICall SELECT count(*) **FACET IF(api like 'amazon%', 'Amazon', if(api like 'google%', 'Google','Everything else')) AS 'Service'**"
+        nrql="FROM Transaction SELECT COUNT(*) **FACET IF(api LIKE 'amazon%', 'Amazon', IF(api LIKE 'google%', 'Google','Everything else')) AS 'Service'**"
+        fallbacknrql="FROM Public_APICall SELECT COUNT(*) **FACET IF(api LIKE 'amazon%', 'Amazon', IF(api LIKE 'google%', 'Google','Everything else')) AS 'Service'**"
         chartType="pie"
         span="12"
       />

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Capture.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Capture.js
@@ -13,8 +13,6 @@ export default function Capture() {
           more efficient but capture() provides more complex regular expression support.
         </Trans>
       </p>
-
-
       <h2>
         <Trans i18nKey="Contents.H1">Capture with aparse()</Trans>
       </h2>
@@ -24,8 +22,7 @@ export default function Capture() {
           provide the string you wish to extract from and a pattern controlling the extraction. The pattern supports 
           two wild cards:<br />
           <code>%</code>- Non capturing wild card<br />
-          <code>8</code>- A capturing wild card
-         
+          <code>*</code>- A capturing wild card
         </Trans>
       </p>
       <p>
@@ -37,26 +34,24 @@ export default function Capture() {
         </Trans>
       </p>
       <SampleQuery
-        nrql="select count(*) from Public_APICall  where http.url like '%amazonaws.com' **facet aparse(http.url,'\*.%') as 'service'**"
-        fallbacknrql="select count(*) from Public_APICall  where http.url like '%amazonaws.com' **facet aparse(http.url,'\*.%') as 'service'**"
+        nrql="SELECT COUNT(*) FROM Transaction WHERE request.headers.host LIKE '%.com' FACET aparse(request.headers.host,'\*.%') AS 'service'**"
+        fallbacknrql="SELECT COUNT(*) FROM Public_APICall WHERE http.url LIKE '%amazonaws.com' **FACET aparse(http.url,'\*.%') AS 'service'**"
         span="12"
         chartType="table"
       />
-
-        <p>
+      <p>
         <Trans i18nKey="Contents.P3">
           If we wanted to extract the region from the string instead then we need this pattern: <code>'%.*.%'</code> This discards 
           everthing matched before the first period, captures everything up to the next period, and disregards the rest:
         </Trans>
       </p>
       <SampleQuery
-        nrql="select count(*) from Public_APICall  where http.url like '%amazonaws.com' **facet aparse(http.url,'%.\*.%') as 'region'**"
-        fallbacknrql="select count(*) from Public_APICall  where http.url like '%amazonaws.com' **facet aparse(http.url,'%.\*.%') as 'region'**"
+        nrql="SELECT COUNT(*) FROM Transaction WHERE request.headers.host LIKE '%.com' FACET aparse(request.headers.host,'%.\*.%') AS 'region'**"
+        fallbacknrql="SELECT COUNT(*) FROM Public_APICall WHERE http.url LIKE '%amazonaws.com' **FACET aparse(http.url,'%.\*.%') AS 'region'**"
         span="12"
         chartType="table"
       />
-
-<p>
+      <p>
         <Trans i18nKey="Contents.P4">
           It is possible to extract more than one field using aparse() but you cant use them directly in the facet. This requires 
           variables which are covered in another section, but whilst we are here lets see how that would look. We need to adjust our 
@@ -66,12 +61,11 @@ export default function Capture() {
         </Trans>
       </p>
       <SampleQuery
-        nrql="FROM Public_APICall **WITH aparse(http.url,'*.*.%') AS (service,region)** SELECT count(*) WHERE http.url like '%amazonaws.com' **FACET service, region**"
-        fallbacknrql="FROM Public_APICall **WITH aparse(http.url,'*.*.%') AS (service,region)** SELECT count(*) WHERE http.url like '%amazonaws.com' **FACET service, region**"
+        nrql="FROM Transaction **WITH aparse(request.headers.host,'\*.\*.%') AS (service,region)** SELECT COUNT(*) WHERE request.headers.host LIKE '%.com' **FACET service, region**"
+        fallbacknrql="FROM Public_APICall **WITH aparse(http.url,'\*.\*.%') AS (service,region)** SELECT COUNT(*) WHERE http.url LIKE '%amazonaws.com' **FACET service, region**"
         span="12"
         chartType="table"
       />
-
       <h2>
         <Trans i18nKey="Contents.H2">Regex Capture</Trans>
       </h2>

--- a/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Capture.js
+++ b/nerdlets/nrql-tutorial-nerdlet/levels/level4/lessons/Capture.js
@@ -71,17 +71,10 @@ export default function Capture() {
       </h2>
       <p>
         <Trans i18nKey="Contents.P5">
-          TBC
+          NRQL also has support for reqex captures which is documented in great detail in the{' '}
+          <a href="https://docs.newrelic.com/docs/nrql/nrql-syntax-clauses-functions/#func-capture" target="_blank">New Relic Docs</a>
         </Trans>
       </p>
-      <SampleQuery
-        nrql="SELECT average(duration) FROM Transaction WHERE entity.guid **IN (SELECT uniques(entity.guid) FROM TransactionError)** FACET appName TIMESERIES"
-        fallbacknrql="SELECT average(duration) FROM Public_APICall WHERE api **IN (SELECT uniques(api) FROM Public_APICall where duration > 2)** FACET api TIMESERIES"
-        span="12"
-        chartType="line"
-      />
-
-      
     </div>
   );
 }


### PR DESCRIPTION
This branch is based on `feature-update-feb23`.

I've updated the remaining few examples to fully support the use of the `Transaction` event type in the queries.
As the section on `regex captures` didn't have any regex related content, I removed the sample query and added a reference to the docs - hoping this could make it into the public release and then be expanded when time allows for it.

For now I've deployed a custom-nerdpack-verison of this app to our account, so it's not urgent for us to have this released to public. However, I do believe the updates in the `feature-update-feb23` branch would benefit a lot of NR customers. 